### PR TITLE
Storage get count

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -83,12 +83,7 @@ class DBStorage:
             if cls not in classes:
                 return None
             cls = classes[cls]
-        obj = models.storage.all(cls).get("{}.{}".format(cls.__name__, id))
-
-        if obj and isinstance(obj, BaseModel):
-            if hasattr(obj, 'city_id') and isinstance(obj.city_id, int):
-                obj.city_id = str(obj.city_id)
-        return obj
+        return models.storage.all(cls).get("{}.{}".format(cls.__name__, id))
 
     def count(self, cls=None):
         """return number of objects in storage matching the given class.

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -78,12 +78,7 @@ class FileStorage:
             if cls not in classes:
                 return None
             cls = classes[cls]
-        obj = models.storage.all(cls).get("{}.{}".format(cls.__name__, id))
-
-        if obj and isinstance(obj, BaseModel):
-            if hasattr(obj, 'city_id') and isinstance(obj.city_id, int):
-                obj.city_id = str(obj.city_id)
-        return obj
+        return models.storage.all(cls).get("{}.{}".format(cls.__name__, id))
 
     def count(self, cls=None):
         """return number of objects in storage matching the given class.

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -97,3 +97,10 @@ class TestDBStorage(unittest.TestCase):
         new_obj = State(name="Test")
         new_obj.save()
         self.assertEqual(models.storage.get("State", new_obj.id), new_obj)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_count(self):
+        """count returns the total number of objects of a given class"""
+        storage = DBStorage()
+        current_total = len(storage.all())
+        self.assertEqual(storage.count(), current_total)

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -118,8 +118,12 @@ class TestFileStorage(unittest.TestCase):
     def test_get(self):
         """test that get returns an object based on given class and id"""
         storage = FileStorage()
-        got_obj = storage.get("State", "fake_id")
-        self.assertIs(got_obj, None)
+        fake_obj = storage.get("fake_State", "fake_id")
+        self.assertIs(fake_obj, None)
+        new_obj = State()
+        new_obj.save()
+        new_obj_id = new_obj.id
+        self.assertIs(storage.get("State", new_obj_id), new_obj)
 
     @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
     def test_count(self):


### PR DESCRIPTION
Now that I have discovered the error I was getting was local, I've removed my attempts at addressing the incompatible data types from both storage files. I have added a test for count and completed the test for the get() method.